### PR TITLE
yt.sh: exclude youtube beta versions

### DIFF
--- a/yt.sh
+++ b/yt.sh
@@ -21,7 +21,7 @@ req() {
 
 get_latestytversion() {
     url="https://www.apkmirror.com/apk/google-inc/youtube/"
-    YTVERSION=$(req "$url" - | grep "All version" -A200 | grep app_release | grep -i beta | head -1 | sed 's:.*/youtube-::g;s:-release/.*::g;s:-:.:g')
+    YTVERSION=$(req "$url" - | grep "All version" -A200 | grep app_release | grep -v beta | head -1 | sed 's:.*/youtube-::g;s:-release/.*::g;s:-:.:g')
     echo "Latest Youtube Version: $YTVERSION"
 }
 


### PR DESCRIPTION
This PR intends to fix a possible bug or unintentional behavior where ONLY BETA versions of YouTube app are downloaded and patched.
If this is intentional behavior then please feel free to decline the PR otherwise I'd like to contribute the fix for it.