### PR TITLE
get latest supported versions using revanced api

### DIFF
--- a/.github/workflows/revanced_official.yml
+++ b/.github/workflows/revanced_official.yml
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Revanced Offical
+
+# Allows you to run this workflow manually from the Actions tab
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 0 * * 0"
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+      - name: Start building
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./yt.sh official

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 YouTube + YouTube Music
 
-Script Runs on Monday and Friday at 07:00AM(IST).\
+Official supported version (Release) script runs on Sunday at 05:30AM(IST).\
+Experimental latest version (Pre-release) script runs on Monday and Friday at 07:00AM(IST).\
 The script will fetch the latest version available.
 
 ReVanced Tools compiled from their latest source.\

--- a/yt.sh
+++ b/yt.sh
@@ -7,7 +7,9 @@ YTMMODULEPATH=$CURDIR/RevancedYTM
 DATE=$(date +%y%m%d)
 BSDIFF=$CURDIR/bin/bsdiff
 DRAFT=false
+IS_PRERELEASE=true
 if [ x${1} == xtest ]; then DRAFT=true; fi
+if [ x${1} == xofficial ]; then IS_PRERELEASE=false; fi
 
 clone() {
     echo "Cleaning and Cloning $1"
@@ -97,7 +99,7 @@ generate_release_data() {
 "name":"RevancedYT-${DATE}-v${1}",
 "body":"$MSG",
 "draft":${DRAFT},
-"prerelease":false,
+"prerelease":${IS_PRERELEASE},
 "generate_release_notes":false
 }
 EOF
@@ -133,8 +135,16 @@ upload_release_file() {
 get_latestytversion
 get_latestytmversion
 
-# TEMP
-YTVERSION=17.45.36
+# Fetch latest official supported YT versions
+if [ $IS_PRERELEASE = false ]; then
+    curl -X 'GET' \
+      'https://releases.rvcd.win/patches' \
+      -H 'accept: application/json' \
+      -o revanced-patches.json
+    YTVERSION=$(jq -r '.[] | select(.name == "video-ads") | .compatiblePackages[] | select(.name == "com.google.android.youtube") | .versions[-1]' revanced-patches.json)
+    YTMVERSION=$(jq -r '.[] | select(.name == "music-video-ads") | .compatiblePackages[] | select(.name == "com.google.android.apps.youtube.music") | .versions[-1]' revanced-patches.json)
+    rm -rf revanced-patches.json
+fi
 
 # Clone Tools
 clone_tools


### PR DESCRIPTION
I suggest having an official release which is always updated as per upstream supported version of the youtube apps by revanced-patches. This can be tagged as "Release" or "Latest". This would build only once a week on Sunday 5:30 AM IST.
This won't have a tendency to fail or at least have a very minimal chance of failing.
You also won't have to regularly check official supported versions manually.

Latest versions of the apps would be experimental and can be tagged using "Pre-release" tag. These would continue to build on their current schedule.

Feel free to add suggestions.